### PR TITLE
.github/workflows/deploy: split build and deploy into separate jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read   # To read the source code
-      pages: write     # To push to a GitHub Pages site
-      id-token: write  # To update the deployment status
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +47,17 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'book'
-
+          retention-days: 90
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write     # To push to a GitHub Pages site
+      id-token: write  # To update the deployment status
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/src/field/hard-mode.md
+++ b/src/field/hard-mode.md
@@ -165,7 +165,7 @@ $ sudo usermod -c "FMS Admin" -G wheel,storage,dialout,docker admin
 > this entire process using a script is more reliable.
 >
 > You can view the exact steps that the CI system performs by
-> examining the `.release/build-fms.sh` script in
+> examining the `.release/build.sh` script in
 > [gizmo-platform/gizmo](https://github.com/gizmo-platform/gizmo).
 > The script includes a handful of extra steps that have to do with
 > running an arm64 software stack on top of an amd64 installation


### PR DESCRIPTION
this allows some privilege separation (e.g., the build process can't write to pages directly) and allows for re-use of the built documentation in https://github.com/gizmo-platform/gizmo/pull/19.

also add concurrency group to prevent pages builds from overlapping and allow the workflow to be run on dispatch
