### PR TITLE
src/code/microblocks: Updates MicroBlocks instructions to reflect new release.

### DIFF
--- a/src/code/microblocks/motor.md
+++ b/src/code/microblocks/motor.md
@@ -24,13 +24,6 @@ The servo block accepts positions from -90 to 90.
 
 ![Set Servo To Position block](/img/microblocks/servo_block.png)
 
-> [!WARNING]
->
-> MicroBlocks version 1.2.95 changed the underlying PWM code. The motor
-> block speed range is -50 to 50 in versions affected by this change. The
-> Gizmo block library will be updated soon to correct the range back to
-> -100 to 100.
-
 ## Sweeping Motor Speeds
 
 This example program runs a motor on Gizmo's motor port 1 through the full

--- a/src/code/microblocks/setup.md
+++ b/src/code/microblocks/setup.md
@@ -7,7 +7,7 @@ MicroBlocks to program it.
 ## Installing the MicroBlocks Firmware
 
 1. Download the firmware .uf2 file from the MicroBlocks downloads page:
-[https://microblocks.fun/downloads/pilot/vm/vm_gizmo_mechatronics.uf2](https://microblocks.fun/downloads/pilot/vm/vm_gizmo_mechatronics.uf2)
+[https://microblocks.fun/downloads/latest/vm/vm_gizmo_mechatronics.uf2](https://microblocks.fun/downloads/latest/vm/vm_gizmo_mechatronics.uf2)
 1. Hold your Gizmo's student processor BOOTSEL ("Boot Select") button down
 while connecting the USB programming cable to your computer. Once you've
 connected the cable, release the BOOTSEL button. You should now see an
@@ -18,7 +18,7 @@ student processor will automatically reset when the installation is done.
 ## Connecting the MicroBlocks Editor to Your Gizmo
 
 The MicroBlocks editor can be accessed online at
-[https://microblocks.fun/run-pilot/](https://microblocks.fun/run-pilot/).
+[https://microblocks.fun/run/](https://microblocks.fun/run/).
 This editor will allow you to create programs without a Gizmo connected.
 You can save and load programs to and from your computer.
 


### PR DESCRIPTION
MicroBlocks v1.2.100 is out and is the stable version available at the normal run URL. The pilot URLs now point to the new 2.0 revamp.
This PR updates Gizmo docs to use the stable links. It also removes the warning about the motor bug which is fixed in the current stable release.