### PR TITLE
book.toml: Add PDF output backend

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,6 +5,11 @@ multilingual = false
 src = "src"
 title = "Gizmo Guide"
 
+[output.html]
+
+[output.pdf]
+optional = true
+
 [preprocessor.callouts]
 
 [preprocessor.d2-go]


### PR DESCRIPTION
The PDF output plugin is somewhat buggy, but its better than not having anything at all for those who want a PDF instead of a web page.  This resolves #11 .